### PR TITLE
Fixing this json field typo

### DIFF
--- a/network.go
+++ b/network.go
@@ -27,7 +27,7 @@ type GetNetworkInventoryItemsResponseResult struct {
 	Total      int `json:"total"`
 	Page       int `json:"page"`
 	PerPage    int `json:"perPage"`
-	PagesCount int `json:"pagesPage"`
+	PagesCount int `json:"pagesCount"`
 
 	Items []GetNetworkInventoryItemsResponseResultItems `json:"items"`
 }
@@ -115,7 +115,7 @@ type GetScanTasksListResponseResult struct {
 	Total      int `json:"total"`
 	Page       int `json:"page"`
 	PerPage    int `json:"perPage"`
-	PagesCount int `json:"pagesPage"`
+	PagesCount int `json:"pagesCount"`
 
 	Items []GetScanTasksListResponseResultItems `json:"items"`
 }
@@ -151,7 +151,7 @@ type GetEndpointsListResponseResult struct {
 	Total      int `json:"total"`
 	Page       int `json:"page"`
 	PerPage    int `json:"perPage"`
-	PagesCount int `json:"pagesPage"`
+	PagesCount int `json:"pagesCount"`
 
 	Items []GetEndpointsListResponseResultItems `json:"items"`
 }


### PR DESCRIPTION
I believe this should be `pagesCount`, its definitely what the API is returning for me at the moment.

Example:

```json
{
    "id": "NULL",
    "jsonrpc": "2.0",
    "result": {
        "total": 69,
        "page": 1,
        "perPage": 5,
        "pagesCount": 14,
        "items": [.....]
    }
}
```